### PR TITLE
Add PangoBasic project files for running the sample on Linux.

### DIFF
--- a/samples/PangoBasic/linux/CMakeLists.txt
+++ b/samples/PangoBasic/linux/CMakeLists.txt
@@ -1,0 +1,48 @@
+# PangoBasic
+cmake_minimum_required( VERSION 2.8 FATAL_ERROR )
+set( CMAKE_VERBOSE_MAKEFILE on )
+
+get_filename_component( CINDER_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../../../../.." ABSOLUTE )
+include( ${CINDER_DIR}/linux/cmake/Cinder.cmake )
+
+project( PangoBasic )
+
+get_filename_component( PANGO_BLOCK_SRC_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../../../src" ABSOLUTE )
+get_filename_component( SRC_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../src" ABSOLUTE )
+get_filename_component( INC_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../include" ABSOLUTE )
+
+if( NOT TARGET cinder${CINDER_LIB_SUFFIX} )
+    find_package( cinder REQUIRED
+        PATHS ${PROJECT_SOURCE_DIR}/../../../../../linux/${CMAKE_BUILD_TYPE}/${CINDER_OUT_DIR_PREFIX}
+        $ENV{Cinder_DIR}/linux/${CMAKE_BUILD_TYPE}/${CINDER_OUT_DIR_PREFIX}
+    )
+endif()
+
+set( CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake )
+
+# Find and include Pango and dependencies.
+find_package( HarfBuzz REQUIRED )
+find_package( Cairo REQUIRED )
+find_package( Pango REQUIRED )
+
+# Use PROJECT_NAME since CMAKE_PROJET_NAME returns the top-level project name.
+set( EXE_NAME ${PROJECT_NAME} )
+
+set( SRC_FILES
+	${SRC_DIR}/PangoBasicApp.cpp
+    ${PANGO_BLOCK_SRC_DIR}/CinderPango.cpp
+)
+
+add_executable( "${EXE_NAME}" ${SRC_FILES} )
+
+target_include_directories(
+	"${EXE_NAME}"
+    PUBLIC ${INC_DIR} 
+           ${PANGO_BLOCK_SRC_DIR}
+           ${HARFBUZZ_INCLUDE_DIRS}
+           ${CAIRO_INCLUDE_DIRS}
+           ${PANGO_INCLUDE_DIRS}
+           
+)
+
+target_link_libraries( "${EXE_NAME}" cinder${CINDER_LIB_SUFFIX} ${HARFBUZZ_LIBRARIES} ${CAIRO_LIBRARIES} ${PANGO_LIBRARIES} )

--- a/samples/PangoBasic/linux/cibuild
+++ b/samples/PangoBasic/linux/cibuild
@@ -1,0 +1,2 @@
+#!/bin/sh
+../../../../../tools/linux/cibuilder -app "$@"

--- a/samples/PangoBasic/linux/cmake/FindCairo.cmake
+++ b/samples/PangoBasic/linux/cmake/FindCairo.cmake
@@ -1,0 +1,81 @@
+# - Try to find Cairo
+# Once done, this will define
+#
+#  CAIRO_FOUND - system has Cairo
+#  CAIRO_INCLUDE_DIRS - the Cairo include directories
+#  CAIRO_LIBRARIES - link these to use Cairo
+#
+# Copyright (C) 2012 Raphael Kubo da Costa <rakuco@webkit.org>
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1.  Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+# 2.  Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDER AND ITS CONTRIBUTORS ``AS
+# IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+# THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+# PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR ITS
+# CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+# EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+# PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+# OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+# WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+# OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+# ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+FIND_PACKAGE(PkgConfig)
+PKG_CHECK_MODULES(PC_CAIRO cairo) # FIXME: After we require CMake 2.8.2 we can pass QUIET to this call.
+
+FIND_PATH(CAIRO_INCLUDE_DIRS
+    NAMES cairo.h
+    HINTS ${PC_CAIRO_INCLUDEDIR}
+          ${PC_CAIRO_INCLUDE_DIRS}
+    PATH_SUFFIXES cairo
+)
+
+FIND_LIBRARY(CAIRO_LIBRARIES
+    NAMES cairo
+    HINTS ${PC_CAIRO_LIBDIR}
+          ${PC_CAIRO_LIBRARY_DIRS}
+)
+
+IF (CAIRO_INCLUDE_DIRS)
+    IF (EXISTS "${CAIRO_INCLUDE_DIRS}/cairo-version.h")
+        FILE(READ "${CAIRO_INCLUDE_DIRS}/cairo-version.h" CAIRO_VERSION_CONTENT)
+
+        STRING(REGEX MATCH "#define +CAIRO_VERSION_MAJOR +([0-9]+)" _dummy "${CAIRO_VERSION_CONTENT}")
+        SET(CAIRO_VERSION_MAJOR "${CMAKE_MATCH_1}")
+
+        STRING(REGEX MATCH "#define +CAIRO_VERSION_MINOR +([0-9]+)" _dummy "${CAIRO_VERSION_CONTENT}")
+        SET(CAIRO_VERSION_MINOR "${CMAKE_MATCH_1}")
+
+        STRING(REGEX MATCH "#define +CAIRO_VERSION_MICRO +([0-9]+)" _dummy "${CAIRO_VERSION_CONTENT}")
+        SET(CAIRO_VERSION_MICRO "${CMAKE_MATCH_1}")
+
+        SET(CAIRO_VERSION "${CAIRO_VERSION_MAJOR}.${CAIRO_VERSION_MINOR}.${CAIRO_VERSION_MICRO}")
+    ENDIF ()
+ENDIF ()
+
+# FIXME: Should not be needed anymore once we start depending on CMake 2.8.3
+SET(VERSION_OK TRUE)
+IF (Cairo_FIND_VERSION)
+    IF (Cairo_FIND_VERSION_EXACT)
+        IF ("${Cairo_FIND_VERSION}" VERSION_EQUAL "${CAIRO_VERSION}")
+            # FIXME: Use IF (NOT ...) with CMake 2.8.2+ to get rid of the ELSE block
+        ELSE ()
+            SET(VERSION_OK FALSE)
+        ENDIF ()
+    ELSE ()
+        IF ("${Cairo_FIND_VERSION}" VERSION_GREATER "${CAIRO_VERSION}")
+            SET(VERSION_OK FALSE)
+        ENDIF ()
+    ENDIF ()
+ENDIF ()
+
+INCLUDE(FindPackageHandleStandardArgs)
+FIND_PACKAGE_HANDLE_STANDARD_ARGS(Cairo DEFAULT_MSG CAIRO_INCLUDE_DIRS CAIRO_LIBRARIES VERSION_OK)

--- a/samples/PangoBasic/linux/cmake/FindHarfBuzz.cmake
+++ b/samples/PangoBasic/linux/cmake/FindHarfBuzz.cmake
@@ -1,0 +1,58 @@
+# - Find HarfBuzz
+#
+# This module tries to find HarfBuzz library and then defines:
+#  HARFBUZZ_FOUND          - True if HarfBuzz library is found
+#  HARFBUZZ_INCLUDE_DIRS   - Include dirs
+#  HARFBUZZ_LIBRARIES      - HarfBuzz libraries
+#
+# Additionally these variables are defined for internal usage:
+#  HARFBUZZ_INCLUDE_DIR    - Include dir (w/o dependencies)
+#  HARFBUZZ_LIBRARY        - HarfBuzz library (w/o dependencies)
+#
+
+#
+#   This file is part of Magnum.
+#
+#   Copyright © 2010, 2011, 2012, 2013, 2014, 2015, 2016
+#             Vladimír Vondruš <mosra@centrum.cz>
+#
+#   Permission is hereby granted, free of charge, to any person obtaining a
+#   copy of this software and associated documentation files (the "Software"),
+#   to deal in the Software without restriction, including without limitation
+#   the rights to use, copy, modify, merge, publish, distribute, sublicense,
+#   and/or sell copies of the Software, and to permit persons to whom the
+#   Software is furnished to do so, subject to the following conditions:
+#
+#   The above copyright notice and this permission notice shall be included
+#   in all copies or substantial portions of the Software.
+#
+#   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+#   IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+#   FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+#   THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+#   LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+#   FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+#   DEALINGS IN THE SOFTWARE.
+#
+
+# Library
+find_library(HARFBUZZ_LIBRARY NAMES harfbuzz)
+
+# Include dir
+find_path(HARFBUZZ_INCLUDE_DIR
+    NAMES hb.h
+    PATH_SUFFIXES harfbuzz
+)
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args("HarfBuzz" DEFAULT_MSG
+    HARFBUZZ_LIBRARY
+    HARFBUZZ_INCLUDE_DIR
+)
+
+set(HARFBUZZ_INCLUDE_DIRS ${HARFBUZZ_INCLUDE_DIR})
+set(HARFBUZZ_LIBRARIES ${HARFBUZZ_LIBRARY})
+
+mark_as_advanced(FORCE
+    HARFBUZZ_LIBRARY
+    HARFBUZZ_INCLUDE_DIR)

--- a/samples/PangoBasic/linux/cmake/FindPango.cmake
+++ b/samples/PangoBasic/linux/cmake/FindPango.cmake
@@ -1,0 +1,47 @@
+# - Try to find the pango library
+# Once done this will define
+#
+#  PANGO_FOUND - system has pango
+#  PANGO_INCLUDE_DIRS - the pango include directory
+#  PANGO_LIBRARIES - Link these to use pango
+#
+# Define PANGO_MIN_VERSION for which version desired.
+#
+
+INCLUDE(FindPkgConfig)
+
+IF(Pango_FIND_REQUIRED)
+        SET(_pkgconfig_REQUIRED "REQUIRED")
+ELSE(Pango_FIND_REQUIRED)
+        SET(_pkgconfig_REQUIRED "")
+ENDIF(Pango_FIND_REQUIRED)
+
+IF(PANGO_MIN_VERSION)
+        PKG_SEARCH_MODULE(PANGO ${_pkgconfig_REQUIRED} "pango>=${PANGO_MIN_VERSION} pangocairo>=${PANGO_MIN_VERSION}")
+ELSE(PANGO_MIN_VERSION)
+        PKG_SEARCH_MODULE(PANGO ${_pkgconfig_REQUIRED} "pango pangocairo")
+ENDIF(PANGO_MIN_VERSION)
+
+IF(NOT PANGO_FOUND AND NOT PKG_CONFIG_FOUND)
+        FIND_PATH(PANGO_INCLUDE_DIRS pango.h)
+        FIND_LIBRARY(PANGO_LIBRARIES pango pangocairo)
+
+        # Report results
+        IF(PANGO_LIBRARIES AND PANGO_INCLUDE_DIRS)
+                SET(PANGO_FOUND 1)
+                IF(NOT Pango_FIND_QUIETLY)
+                        MESSAGE(STATUS "Found Pango: ${PANGO_LIBRARIES}")
+                ENDIF(NOT Pango_FIND_QUIETLY)
+        ELSE(PANGO_LIBRARIES AND PANGO_INCLUDE_DIRS)
+                IF(Pango_FIND_REQUIRED)
+                        MESSAGE(SEND_ERROR "Could not find Pango")
+                ELSE(Pango_FIND_REQUIRED)
+                        IF(NOT Pango_FIND_QUIETLY)
+                                MESSAGE(STATUS "Could not find Pango")
+                        ENDIF(NOT Pango_FIND_QUIETLY)
+                ENDIF(Pango_FIND_REQUIRED)
+        ENDIF(PANGO_LIBRARIES AND PANGO_INCLUDE_DIRS)
+ENDIF(NOT PANGO_FOUND AND NOT PKG_CONFIG_FOUND)
+
+# Hide advanced variables from CMake GUIs
+MARK_AS_ADVANCED(PANGO_LIBRARIES PANGO_INCLUDE_DIRS)


### PR DESCRIPTION
Hi, just tried the sample on Linux and it looks good. The only requirements are the installation of **harfbuzz**, **cairo**, **pango** and the presence of  a _gcc_ version >= 4.9 because of `regex_replace` .  

On Debian based systems that use `apt` as their package manager ( Ubuntu and so on ) for installing the libraries it would be :

`sudo apt-get install libharfbuzz-dev libcairo2-dev libpango1.0-dev`

The project files are pretty small thanks to CMake and `find_package` and the process for building the sample is the same as with the other Cinder Linux samples ( [wiki link](https://github.com/cinder/Cinder/wiki/Cinder-for-Linux) ).
